### PR TITLE
do not request a shell on the remote host

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -18,6 +18,7 @@ echo [INFO] Tunneling ${SSH_HOSTUSER:=root}@${SSH_HOSTNAME:=localhost}:${SSH_TUN
 
 echo autossh \
  -M 0 \
+ -N \
  -o StrictHostKeyChecking=${STRICT_HOSTS_KEY_CHECKING} ${KNOWN_HOSTS_ARG:=} \
  -o ServerAliveInterval=5 \
  -o ServerAliveCountMax=1 \
@@ -33,6 +34,7 @@ AUTOSSH_LOGLEVEL=0 \
 AUTOSSH_LOGFILE=/dev/stdout \
 autossh \
  -M 0 \
+ -N \
  -o StrictHostKeyChecking=${STRICT_HOSTS_KEY_CHECKING} ${KNOWN_HOSTS_ARG:=}  \
  -o ServerAliveInterval=5 \
  -o ServerAliveCountMax=1 \


### PR DESCRIPTION
starting a remote command is not used or necessary for a forward-only connection
plus the SSH_HOSTUSER@SSH_HOSTNAME is not even guaranteed to have this permission,
 in which case the server will always close the link after authentication,
 leading to an infinite retry loop