### PR TITLE
enable StrictHostKeyChecking if hosts file is provided

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -3,6 +3,14 @@
 touch /id_rsa
 chmod 0400 /id_rsa
 
+STRICT_HOSTS_KEY_CHECKING=no
+KNOWN_HOSTS=${KNOWN_HOSTS_FILE:=/known_hosts}
+if [ -f "${KNOWN_HOSTS}" ]; then
+    chmod 0400 ${KNOWN_HOSTS}
+    KNOWN_HOSTS_ARG="-o UserKnownHostsFile=${KNOWN_HOSTS}"
+    STRICT_HOSTS_KEY_CHECKING=yes
+fi
+
 # Pick a random port above 32768
 DEFAULT_PORT=$RANDOM
 let "DEFAULT_PORT += 32768"
@@ -10,7 +18,7 @@ echo [INFO] Tunneling ${SSH_HOSTUSER:=root}@${SSH_HOSTNAME:=localhost}:${SSH_TUN
 
 echo autossh \
  -M 0 \
- -o StrictHostKeyChecking=no \
+ -o StrictHostKeyChecking=${STRICT_HOSTS_KEY_CHECKING} ${KNOWN_HOSTS_ARG:=} \
  -o ServerAliveInterval=5 \
  -o ServerAliveCountMax=1 \
  -t -t \
@@ -25,7 +33,7 @@ AUTOSSH_LOGLEVEL=0 \
 AUTOSSH_LOGFILE=/dev/stdout \
 autossh \
  -M 0 \
- -o StrictHostKeyChecking=no \
+ -o StrictHostKeyChecking=${STRICT_HOSTS_KEY_CHECKING} ${KNOWN_HOSTS_ARG:=}  \
  -o ServerAliveInterval=5 \
  -o ServerAliveCountMax=1 \
  -t -t \


### PR DESCRIPTION
Host key checking is enabled if /known_hosts file exists.
Alternately, an environment variable KNOWN_HOSTS_FILE can be used
 to provide the known_hosts path.
If no such file is provided, StrictHostKeyChecking remains disabled.