### PR TITLE
Prevent stale connections when forwarding failed to initialize

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -22,6 +22,7 @@ echo autossh \
  -o StrictHostKeyChecking=${STRICT_HOSTS_KEY_CHECKING} ${KNOWN_HOSTS_ARG:=} \
  -o ServerAliveInterval=5 \
  -o ServerAliveCountMax=1 \
+ -o "ExitOnForwardFailure yes" \
  -t -t \
  -i ${SSH_KEY_FILE:=/id_rsa} \
  ${SSH_MODE:=-R} ${SSH_TUNNEL_REMOTE}:${SSH_TUNNEL_HOST}:${SSH_TUNNEL_LOCAL} \
@@ -38,6 +39,7 @@ autossh \
  -o StrictHostKeyChecking=${STRICT_HOSTS_KEY_CHECKING} ${KNOWN_HOSTS_ARG:=}  \
  -o ServerAliveInterval=5 \
  -o ServerAliveCountMax=1 \
+ -o "ExitOnForwardFailure yes" \
  -t -t \
  -i ${SSH_KEY_FILE:=/id_rsa} \
  ${SSH_MODE:=-R} ${SSH_TUNNEL_REMOTE}:${SSH_TUNNEL_HOST}:${SSH_TUNNEL_LOCAL} \


### PR DESCRIPTION
I experienced the case that after a network glitch, the ssh tunnel successfully reconnected, but the actual port forwarding failed to be set up with the following log message:
```
Warning: remote port forwarding failed for listen port XXXX
```

Most likely, the old connection was still known to the SSH server and thus the forwarding port was still in use. Now the client connected again, before the old connection was reaped and therefore the forwarding port was freed.

In order to prevent this from happening in the future, the Docker container should exit, if port forwarding fails to initialize, as this gives Docker's restart policy a chance to kick in.

Thanks & kind regards