### PR TITLE
Cleanup & refactor Dockerfile and init script

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.9.4
+FROM alpine:latest
 
 ARG BUILD_DATE
 ARG VCS_REF
@@ -12,19 +12,7 @@ LABEL org.opencontainers.image.ref.name="jnovack/autossh" \
       org.opencontainers.image.revision=$COMMIT \
       org.opencontainers.image.url="https://hub.docker.com/r/jnovack/autossh/"
 
-ENTRYPOINT ["/entrypoint.sh"]
-ADD /entrypoint.sh /entrypoint.sh
-RUN chmod 755 /entrypoint.sh
+RUN apk --no-cache add autossh openssh-client
+COPY /entrypoint.sh /init
 
-ENV \
-    TERM=xterm \
-    AUTOSSH_LOGFILE=/dev/stdout \
-    AUTOSSH_GATETIME=30         \
-    AUTOSSH_POLL=30             \
-    AUTOSSH_FIRST_POLL=30       \
-    AUTOSSH_LOGLEVEL=1
-
-RUN echo "http://dl-cdn.alpinelinux.org/alpine/edge/community/" >> /etc/apk/repositories && \
-    apk update && \
-    apk add --update autossh openssh-client && \
-    rm -rf /var/lib/apt/lists/*
+CMD [ "/init" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,10 @@ LABEL org.opencontainers.image.ref.name="jnovack/autossh" \
       org.opencontainers.image.revision=$COMMIT \
       org.opencontainers.image.url="https://hub.docker.com/r/jnovack/autossh/"
 
-RUN apk --no-cache add autossh openssh-client
-COPY /entrypoint.sh /init
+RUN apk --no-cache add \
+	autossh \
+	openssh-client \
+	dumb-init
+COPY /entrypoint.sh /entrypoint.sh
 
-CMD [ "/init" ]
+ENTRYPOINT [ "/entrypoint.sh" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM alpine:latest
 
-ARG BUILD_DATE
-ARG VCS_REF
+ARG BUILD_RFC3339
+ARG COMMIT
 LABEL org.opencontainers.image.ref.name="jnovack/autossh" \
       org.opencontainers.image.created=$BUILD_RFC3339 \
       org.opencontainers.image.authors="Justin J. Novack <jnovack@gmail.com>" \

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,7 @@ FROM alpine:latest
 
 ARG BUILD_RFC3339
 ARG COMMIT
+ARG VERSION
 LABEL org.opencontainers.image.ref.name="jnovack/autossh" \
       org.opencontainers.image.created=$BUILD_RFC3339 \
       org.opencontainers.image.authors="Justin J. Novack <jnovack@gmail.com>" \
@@ -10,11 +11,11 @@ LABEL org.opencontainers.image.ref.name="jnovack/autossh" \
       org.opencontainers.image.licenses="MIT" \
       org.opencontainers.image.source="https://github.com/jnovack/docker-autossh" \
       org.opencontainers.image.revision=$COMMIT \
+      org.opencontainers.image.version=$VERSION \
       org.opencontainers.image.url="https://hub.docker.com/r/jnovack/autossh/"
 
 RUN apk --no-cache add \
 	autossh \
-	openssh-client \
 	dumb-init
 COPY /entrypoint.sh /entrypoint.sh
 

--- a/Dockerfile.arm32v7
+++ b/Dockerfile.arm32v7
@@ -20,20 +20,7 @@ LABEL org.opencontainers.image.ref.name="jnovack/autossh" \
       org.opencontainers.image.revision=$COMMIT \
       org.opencontainers.image.url="https://hub.docker.com/r/jnovack/autossh/"
 
-ENTRYPOINT ["/entrypoint.sh"]
-ADD /entrypoint.sh /entrypoint.sh
-RUN chmod 755 /entrypoint.sh
+RUN apk --no-cache add autossh openssh-client
+COPY /entrypoint.sh /init
 
-ENV \
-    TERM=xterm \
-    AUTOSSH_LOGFILE=/dev/stdout \
-    AUTOSSH_GATETIME=30         \
-    AUTOSSH_POLL=10             \
-    AUTOSSH_FIRST_POLL=30       \
-    AUTOSSH_LOGLEVEL=1
-
-RUN apk update && \
-    echo "http://dl-cdn.alpinelinux.org/alpine/edge/community/" >> /etc/apk/repositories && \
-    apk add --update autossh && \
-    apk add --update openssh-client && \
-    rm -rf /var/lib/apt/lists/*
+CMD [ "/init" ]

--- a/Dockerfile.arm32v7
+++ b/Dockerfile.arm32v7
@@ -10,6 +10,7 @@ COPY --from=builder /qemu-arm-static /usr/bin
 
 ARG BUILD_RFC3339
 ARG COMMIT
+ARG VERSION
 LABEL org.opencontainers.image.ref.name="jnovack/autossh" \
       org.opencontainers.image.created=$BUILD_RFC3339 \
       org.opencontainers.image.authors="Justin J. Novack <jnovack@gmail.com>" \
@@ -18,11 +19,11 @@ LABEL org.opencontainers.image.ref.name="jnovack/autossh" \
       org.opencontainers.image.licenses="MIT" \
       org.opencontainers.image.source="https://github.com/jnovack/docker-autossh" \
       org.opencontainers.image.revision=$COMMIT \
+      org.opencontainers.image.version=$VERSION \
       org.opencontainers.image.url="https://hub.docker.com/r/jnovack/autossh/"
 
 RUN apk --no-cache add \
 	autossh \
-	openssh-client \
 	dumb-init
 COPY /entrypoint.sh /entrypoint.sh
 

--- a/Dockerfile.arm32v7
+++ b/Dockerfile.arm32v7
@@ -8,8 +8,8 @@ FROM arm32v7/alpine:latest
 # Copy across the qemu binary that was downloaded in the previous build step
 COPY --from=builder /qemu-arm-static /usr/bin
 
-ARG BUILD_DATE
-ARG VCS_REF
+ARG BUILD_RFC3339
+ARG COMMIT
 LABEL org.opencontainers.image.ref.name="jnovack/autossh" \
       org.opencontainers.image.created=$BUILD_RFC3339 \
       org.opencontainers.image.authors="Justin J. Novack <jnovack@gmail.com>" \

--- a/Dockerfile.arm32v7
+++ b/Dockerfile.arm32v7
@@ -20,7 +20,10 @@ LABEL org.opencontainers.image.ref.name="jnovack/autossh" \
       org.opencontainers.image.revision=$COMMIT \
       org.opencontainers.image.url="https://hub.docker.com/r/jnovack/autossh/"
 
-RUN apk --no-cache add autossh openssh-client
-COPY /entrypoint.sh /init
+RUN apk --no-cache add \
+	autossh \
+	openssh-client \
+	dumb-init
+COPY /entrypoint.sh /entrypoint.sh
 
-CMD [ "/init" ]
+ENTRYPOINT [ "/entrypoint.sh" ]

--- a/README.md
+++ b/README.md
@@ -129,12 +129,13 @@ tunnel exit, or destination service.  Typically this is `ssh` (port: 22),
 however, you can tunnel other services such as redis (port: 6379),
 elasticsearch (port: 9200) or good old http (port: 80) and https (port: 443).
 
-#### SSH_STRICT_HOST_IP_CHECK
+#### SSH_NO_STRICT_HOST_IP_CHECK
 
-Specify if you want the IP addresses of hosts to also be checked, if the
-`known_hosts` file is provided. This can cause issues for hosts with
-dynamic IP addresses, but provides additional protection for against DNS
-spoofing attacks.  (Default: disabled, set to any non-empty string to enable)
+Specify if you want the IP addresses of hosts to not be checked if the
+`known_hosts` file is provided.  This can avoid issues for hosts with
+dynamic IP addresses, but removes some additional protection against DNS
+spoofing attacks.  Host IP Checking is enabled by default, set this variable
+to any value to disable.
 
 #### SSH_KEY_FILE
 

--- a/README.md
+++ b/README.md
@@ -129,6 +129,13 @@ tunnel exit, or destination service.  Typically this is `ssh` (port: 22),
 however, you can tunnel other services such as redis (port: 6379),
 elasticsearch (port: 9200) or good old http (port: 80) and https (port: 443).
 
+#### SSH_STRICT_HOST_IP_CHECK
+
+Specify if you want the IP addresses of hosts to also be checked, if the
+`known_hosts` file is provided. This can cause issues for hosts with
+dynamic IP addresses, but provides additional protection for against DNS
+spoofing attacks.  (Default: disabled, set to any non-empty string to enable)
+
 #### SSH_KEY_FILE
 
 In the event you wish to store the key in Docker Secrets, you may wish to

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,46 +1,52 @@
 #!/bin/sh
 
-touch ${SSH_KEY_FILE:=/id_rsa}
-chmod 0400 ${SSH_KEY_FILE:=/id_rsa}
+# Set up key file
+KEY_FILE=${SSH_KEY_FILE:=/id_rsa}
+if [ ! -f "${KEY_FILE}" ]; then
+	echo "[ERROR] No SSH Key file found"
+	exit 1
+fi
+eval $(ssh-agent -s)
+cat "${SSH_KEY_FILE}" | ssh-add -k -
 
+# Set up known_hosts file if needed
 STRICT_HOSTS_KEY_CHECKING=no
 KNOWN_HOSTS=${SSH_KNOWN_HOSTS:=/known_hosts}
 if [ -f "${KNOWN_HOSTS}" ]; then
-    chmod 0400 ${KNOWN_HOSTS}
-    KNOWN_HOSTS_ARG="-o UserKnownHostsFile=${KNOWN_HOSTS}"
+    KNOWN_HOSTS_ARG="-o UserKnownHostsFile=${KNOWN_HOSTS} "
     STRICT_HOSTS_KEY_CHECKING=yes
 fi
 
 # Pick a random port above 32768
 DEFAULT_PORT=$RANDOM
 let "DEFAULT_PORT += 32768"
-echo [INFO] Tunneling ${SSH_HOSTUSER:=root}@${SSH_HOSTNAME:=localhost}:${SSH_TUNNEL_REMOTE:=${DEFAULT_PORT}} to ${SSH_TUNNEL_HOST=localhost}:${SSH_TUNNEL_LOCAL:=22}
-eval $(ssh-agent -s)
-cat ${SSH_KEY_FILE} | ssh-add -k -
-echo autossh \
- -M 0 \
- -N \
- -o StrictHostKeyChecking=${STRICT_HOSTS_KEY_CHECKING} ${KNOWN_HOSTS_ARG:=} \
- -o ServerAliveInterval=10 \
- -o ServerAliveCountMax=3 \
- -o ExitOnForwardFailure=yes \
- -t -t \
- ${SSH_MODE:=-R} ${SSH_TUNNEL_REMOTE}:${SSH_TUNNEL_HOST}:${SSH_TUNNEL_LOCAL} \
- -p ${SSH_HOSTPORT:=22} \
- ${SSH_HOSTUSER}@${SSH_HOSTNAME}
 
+# Determine command line flags
+COMMAND="autossh "\
+"-M 0 "\
+"-N "\
+"-o StrictHostKeyChecking=${STRICT_HOSTS_KEY_CHECKING} ${KNOWN_HOSTS_ARG:=}"\
+"-o ServerAliveInterval=10 "\
+"-o ServerAliveCountMax=3 "\
+"-o ExitOnForwardFailure=yes "\
+"-t -t "\
+"${SSH_MODE:=-R} ${SSH_TUNNEL_REMOTE}:${SSH_TUNNEL_HOST}:${SSH_TUNNEL_LOCAL} "\
+"-p ${SSH_HOSTPORT:=22} "\
+"${SSH_HOSTUSER}@${SSH_HOSTNAME}"
+
+# Log to stdout
+INFO_TUNNEL_SRC="${SSH_HOSTUSER:=root}@${SSH_HOSTNAME:=localhost}:${SSH_TUNNEL_REMOTE:=${DEFAULT_PORT}}"
+INFO_TUNNEL_DEST="${SSH_TUNNEL_HOST=localhost}:${SSH_TUNNEL_LOCAL:=22}"
+
+echo "[INFO] Using $(autossh -V)"
+echo "[INFO] Tunneling ${INFO_TUNNEL_SRC} to ${INFO_TUNNEL_DEST}"
+echo "> ${COMMAND}"
+
+# Run command
 AUTOSSH_PIDFILE=/autossh.pid \
 AUTOSSH_POLL=30 \
+AUTOSSH_GATETIME=30 \
+AUTOSSH_FIRST_POLL=30 \
 AUTOSSH_LOGLEVEL=0 \
 AUTOSSH_LOGFILE=/dev/stdout \
-autossh \
- -M 0 \
- -N \
- -o StrictHostKeyChecking=${STRICT_HOSTS_KEY_CHECKING} ${KNOWN_HOSTS_ARG:=}  \
- -o ServerAliveInterval=10 \
- -o ServerAliveCountMax=3 \
- -o ExitOnForwardFailure=yes \
- -t -t \
- ${SSH_MODE:=-R} ${SSH_TUNNEL_REMOTE}:${SSH_TUNNEL_HOST}:${SSH_TUNNEL_LOCAL} \
- -p ${SSH_HOSTPORT:=22} \
- ${SSH_HOSTUSER}@${SSH_HOSTNAME}
+exec ${COMMAND}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -13,7 +13,7 @@ cat "${SSH_KEY_FILE}" | ssh-add -k -
 STRICT_HOSTS_KEY_CHECKING=no
 KNOWN_HOSTS=${SSH_KNOWN_HOSTS:=/known_hosts}
 if [ -f "${KNOWN_HOSTS}" ]; then
-    KNOWN_HOSTS_ARG="-o UserKnownHostsFile=${KNOWN_HOSTS} "
+    KNOWN_HOSTS_ARG="-o UserKnownHostsFile=${KNOWN_HOSTS} -o CheckHostIP=no "
     STRICT_HOSTS_KEY_CHECKING=yes
 fi
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/dumb-init /bin/sh
 
 # Set up key file
 KEY_FILE=${SSH_KEY_FILE:=/id_rsa}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -3,8 +3,8 @@
 # Set up key file
 KEY_FILE=${SSH_KEY_FILE:=/id_rsa}
 if [ ! -f "${KEY_FILE}" ]; then
-	echo "[ERROR] No SSH Key file found"
-	exit 1
+    echo "[ERROR] No SSH Key file found"
+    exit 1
 fi
 eval $(ssh-agent -s)
 cat "${SSH_KEY_FILE}" | ssh-add -k -
@@ -13,7 +13,10 @@ cat "${SSH_KEY_FILE}" | ssh-add -k -
 STRICT_HOSTS_KEY_CHECKING=no
 KNOWN_HOSTS=${SSH_KNOWN_HOSTS:=/known_hosts}
 if [ -f "${KNOWN_HOSTS}" ]; then
-    KNOWN_HOSTS_ARG="-o UserKnownHostsFile=${KNOWN_HOSTS} -o CheckHostIP=no "
+    KNOWN_HOSTS_ARG="-o UserKnownHostsFile=${KNOWN_HOSTS} "
+    if [ -z "${SSH_STRICT_HOST_IP_CHECK:=}" ]; then
+        KNOWN_HOSTS_ARG="${KNOWN_HOSTS_ARG}-o CheckHostIP=no "
+    fi
     STRICT_HOSTS_KEY_CHECKING=yes
 fi
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -14,7 +14,7 @@ STRICT_HOSTS_KEY_CHECKING=no
 KNOWN_HOSTS=${SSH_KNOWN_HOSTS:=/known_hosts}
 if [ -f "${KNOWN_HOSTS}" ]; then
     KNOWN_HOSTS_ARG="-o UserKnownHostsFile=${KNOWN_HOSTS} "
-    if [ -z "${SSH_STRICT_HOST_IP_CHECK:=}" ]; then
+    if [ -n ${SSH_NO_STRICT_HOST_IP_CHECK+x} ]; then
         KNOWN_HOSTS_ARG="${KNOWN_HOSTS_ARG}-o CheckHostIP=no "
     fi
     STRICT_HOSTS_KEY_CHECKING=yes
@@ -25,6 +25,8 @@ DEFAULT_PORT=$RANDOM
 let "DEFAULT_PORT += 32768"
 
 # Determine command line flags
+INFO_TUNNEL_SRC="${SSH_HOSTUSER:=root}@${SSH_HOSTNAME:=localhost}:${SSH_TUNNEL_REMOTE:=${DEFAULT_PORT}}"
+INFO_TUNNEL_DEST="${SSH_TUNNEL_HOST=localhost}:${SSH_TUNNEL_LOCAL:=22}"
 COMMAND="autossh "\
 "-M 0 "\
 "-N "\
@@ -38,9 +40,6 @@ COMMAND="autossh "\
 "${SSH_HOSTUSER}@${SSH_HOSTNAME}"
 
 # Log to stdout
-INFO_TUNNEL_SRC="${SSH_HOSTUSER:=root}@${SSH_HOSTNAME:=localhost}:${SSH_TUNNEL_REMOTE:=${DEFAULT_PORT}}"
-INFO_TUNNEL_DEST="${SSH_TUNNEL_HOST=localhost}:${SSH_TUNNEL_LOCAL:=22}"
-
 echo "[INFO] Using $(autossh -V)"
 echo "[INFO] Tunneling ${INFO_TUNNEL_SRC} to ${INFO_TUNNEL_DEST}"
 echo "> ${COMMAND}"

--- a/hooks/build
+++ b/hooks/build
@@ -7,5 +7,6 @@ echo "[***] Build hook running"
 
 docker build \
     --build-arg BUILD_RFC3339=$(date -u +"%Y-%m-%dT%H:%M:%SZ") \
-    --build-arg COMMIT=`git rev-parse --short HEAD` \
+    --build-arg COMMIT=$(git rev-parse --short HEAD) \
+    --build-arg VERSION=$(git describe --tags --always) \
     -t $IMAGE_NAME .

--- a/hooks/build
+++ b/hooks/build
@@ -1,4 +1,3 @@
-#!/bin/sh
 #!/bin/bash
 # hooks/build
 # https://docs.docker.com/docker-cloud/builds/advanced/
@@ -7,10 +6,6 @@
 echo "[***] Build hook running"
 
 docker build \
-    --build-arg VERSION=$(git describe --tags --always) \
     --build-arg BUILD_RFC3339=$(date -u +"%Y-%m-%dT%H:%M:%SZ") \
-    --build-arg BUILD_DATE=`date +%F` \
-    --build-arg BUILD_TIME=`date +%T%z` \
     --build-arg COMMIT=`git rev-parse --short HEAD` \
-    --build-arg BRANCH=$(git rev-parse --abbrev-ref HEAD) \
     -t $IMAGE_NAME .


### PR DESCRIPTION
Refactor of Dockerfiles:
- Changed x86 Dockerfile to use latest stable release of Alpine, which matches the ARM Dockerfile
- Don't need to add the edge repos, as both the ssh client and autossh are available on stable from at least v3.9 onwards
- Dropped the `ENV` declaration, they were already being defined in the init script anyway
- Use `apk --no-cache` for a clean one-liner
- No need to to `chmod` the init script if it already is saved with the execute bit in the repo
- Using `CMD` over `ENTRYPOINT`, see https://stackoverflow.com/questions/21553353/
- Renamed 'entrypoint.sh' to 'init' to avoid confusion in regards to the above

Refactor of init script:
- Removed the `chmod` calls to `/id_rsa` and `/known_hosts`. I typically mount these as read-only in my usage, and this causes warnings from these commands to be thrown, but autossh will still function normally, so I don't think they are needed.
- Quickly check to make sure a keyfile is actually mounted
- Add flag `CheckHostIP=no` when `/known_hosts` is used. IMO this makes this a lot more usable for connecting to dynamic IP servers. Readup here: https://unix.stackexchange.com/a/285551
- Avoid repeating code: specify the command string once, and use it for both the log and for actual execution