### PR TITLE
Make autossh runnable as non-root user (e.g. Openshift)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,13 +14,15 @@ LABEL org.opencontainers.image.ref.name="jnovack/autossh" \
       org.opencontainers.image.version=$VERSION \
       org.opencontainers.image.url="https://hub.docker.com/r/jnovack/autossh/"
 
-RUN apk --no-cache add \
-	autossh \
-  net-tools \
-	dumb-init
+RUN \
+  apk --no-cache add \
+	  autossh \
+    net-tools \
+	  dumb-init && \
+  chmod g+w /etc/passwd
 
 ENV \
-  AUTOSSH_PIDFILE=/autossh.pid \
+  AUTOSSH_PIDFILE=/tmp/autossh.pid \
   AUTOSSH_POLL=30 \
   AUTOSSH_GATETIME=30 \
   AUTOSSH_FIRST_POLL=30 \

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,7 @@ LABEL org.opencontainers.image.ref.name="jnovack/autossh" \
 
 RUN apk --no-cache add \
 	autossh \
+  net-tools \
 	dumb-init
 
 ENV \

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,15 @@ LABEL org.opencontainers.image.ref.name="jnovack/autossh" \
 RUN apk --no-cache add \
 	autossh \
 	dumb-init
+
+ENV \
+  AUTOSSH_PIDFILE=/autossh.pid \
+  AUTOSSH_POLL=30 \
+  AUTOSSH_GATETIME=30 \
+  AUTOSSH_FIRST_POLL=30 \
+  AUTOSSH_LOGLEVEL=0 \
+  AUTOSSH_LOGFILE=/dev/stdout
+
 COPY /entrypoint.sh /entrypoint.sh
 
 ENTRYPOINT [ "/entrypoint.sh" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,9 +16,9 @@ LABEL org.opencontainers.image.ref.name="jnovack/autossh" \
 
 RUN \
   apk --no-cache add \
-	  autossh \
+    autossh \
     net-tools \
-	  dumb-init && \
+    dumb-init && \
   chmod g+w /etc/passwd
 
 ENV \

--- a/Dockerfile.arm32v7
+++ b/Dockerfile.arm32v7
@@ -25,6 +25,15 @@ LABEL org.opencontainers.image.ref.name="jnovack/autossh" \
 RUN apk --no-cache add \
 	autossh \
 	dumb-init
+
+ENV \
+  AUTOSSH_PIDFILE=/autossh.pid \
+  AUTOSSH_POLL=30 \
+  AUTOSSH_GATETIME=30 \
+  AUTOSSH_FIRST_POLL=30 \
+  AUTOSSH_LOGLEVEL=0 \
+  AUTOSSH_LOGFILE=/dev/stdout
+
 COPY /entrypoint.sh /entrypoint.sh
 
 ENTRYPOINT [ "/entrypoint.sh" ]

--- a/Dockerfile.arm32v7
+++ b/Dockerfile.arm32v7
@@ -24,6 +24,7 @@ LABEL org.opencontainers.image.ref.name="jnovack/autossh" \
 
 RUN apk --no-cache add \
 	autossh \
+  net-tools \
 	dumb-init
 
 ENV \

--- a/Dockerfile.arm32v7
+++ b/Dockerfile.arm32v7
@@ -22,13 +22,15 @@ LABEL org.opencontainers.image.ref.name="jnovack/autossh" \
       org.opencontainers.image.version=$VERSION \
       org.opencontainers.image.url="https://hub.docker.com/r/jnovack/autossh/"
 
-RUN apk --no-cache add \
-	autossh \
-  net-tools \
-	dumb-init
+RUN \
+  apk --no-cache add \
+	  autossh \
+    net-tools \
+	  dumb-init && \
+  chmod g+w /etc/passwd
 
 ENV \
-  AUTOSSH_PIDFILE=/autossh.pid \
+  AUTOSSH_PIDFILE=/tmp/autossh.pid \
   AUTOSSH_POLL=30 \
   AUTOSSH_GATETIME=30 \
   AUTOSSH_FIRST_POLL=30 \

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -39,8 +39,8 @@ COMMAND="autossh "\
 "-M 0 "\
 "-N "\
 "-o StrictHostKeyChecking=${STRICT_HOSTS_KEY_CHECKING} ${KNOWN_HOSTS_ARG:=}"\
-"-o ServerAliveInterval=10 "\
-"-o ServerAliveCountMax=3 "\
+"-o ServerAliveInterval=${SERVER_ALIVE_INTERVAL:-10} "\
+"-o ServerAliveCountMax=${SERVER_ALIVE_COUNT_MAX:-3} "\
 "-o ExitOnForwardFailure=yes "\
 "-t -t "\
 "${SSH_MODE:=-R} ${SSH_TUNNEL_REMOTE}:${SSH_TUNNEL_HOST}:${SSH_TUNNEL_LOCAL} "\

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -46,10 +46,4 @@ echo "[INFO] Tunneling ${INFO_TUNNEL_SRC} to ${INFO_TUNNEL_DEST}"
 echo "> ${COMMAND}"
 
 # Run command
-AUTOSSH_PIDFILE=/autossh.pid \
-AUTOSSH_POLL=30 \
-AUTOSSH_GATETIME=30 \
-AUTOSSH_FIRST_POLL=30 \
-AUTOSSH_LOGLEVEL=0 \
-AUTOSSH_LOGFILE=/dev/stdout \
 exec ${COMMAND}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -21,6 +21,13 @@ if [ -f "${KNOWN_HOSTS}" ]; then
     STRICT_HOSTS_KEY_CHECKING=yes
 fi
 
+# Add entry to /etc/passwd if we are running non-root
+if [[ $(id -u) != "0" ]]; then
+  USER="autossh:x:$(id -u):$(id -g):autossh:/tmp:/bin/sh"
+  echo "Creating non-root-user = $USER"
+  echo "$USER" >> /etc/passwd
+fi
+
 # Pick a random port above 32768
 DEFAULT_PORT=$RANDOM
 let "DEFAULT_PORT += 32768"


### PR DESCRIPTION
### What this PR does

* Adds `net-tools` package for debugging
* Make [Autossh environment variables](https://linux.die.net/man/1/autossh) configurable instead of hardcoded
* Make image runnable as non-root user

### Why this PR is needed

* Debugging an autossh issue with connections is hard without the proper tools installed. I think this is a trade-off against size & attack surface we can afford. If you have any objections, I'll remove that.
* In Openshift, containers get assigned an arbitrary user id (e.g. `16300100:0`). This means that most containers on Docker Hub do not run out-of-the-box (it also means that most images on Hub are not secure, as they run as root...) . To make it compatible with any user id, we need to fix some permissions. In the case of (auto)ssh, it makes a lookup to `/etc/passwd` file to search for the user, otherwise it refuses to start up. An easy but not-so-ideal solution is to make it writable for root group, so that we can add the entry at runtime. The [more-sophisticated way](https://stackoverflow.com/questions/47706024/docker-set-running-user-while-launch-container/57531352#57531352) is probably overkill. Let me know your preference here.